### PR TITLE
Iss #36/migrate contao members to phpbb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,13 @@ nbproject/
 /vendor/
 /src/Resources/phpBB/ctsmedia/contaophpbbbridge/vendor/
 composer.lock
+!src/Resources/phpBB/ctsmedia/contaophpbbbridge/composer.lock
 
 #### bridge generated files
 src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/contao.yml
 src/Resources/phpBB/ctsmedia/contaophpbbbridge/styles/all/template/*.html
 src/Resources/phpBB/ctsmedia/contaophpbbbridge/styles/all/template/event/*.html
+src/Resources/phpBB/ctsmedia/contaophpbbbridge/*.log
 
 #### Other
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -32,7 +32,9 @@ environment within minutes.
 Run `docker exec contao_phpbb_bridge_php mv /var/www/share/project/web/phpbb/install /var/www/share/project/web/phpbb/install123`  
 You can access your phpbb installation now at http://localhost/phpbb/
 
-5. Now follow the [installation guide](installation.md) for setting up the bridge. Continue / Start at step 5.  
+5. If you have mounted the local source folder in the docker container (default) then run `composer install --ignore-platform-reqs --no-scripts -d src/Resources/phpBB/ctsmedia/contao-phpbb-bridge-bundle/src/Resources/phpBB/ctsmedia/contaophpbbbridge`
+
+6. Now follow the [installation guide](installation.md) for setting up the bridge. Continue / Start at step 5.  
 You've at least to setup a website root and layout in Contao. Remember the admin user for contao is the one from the demo installation: k.jones
 
 **Info:** You should not use localhost as domain, as this leads to problems that the php fpm container tries to connect to itself instead of the web container. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,10 @@ services:
       MYSQL_DATABASE: *project
       MYSQL_USER: *project
       MYSQL_PASSWORD: *project
+
+  phpmyadmin:
+        image: phpmyadmin/phpmyadmin
+        depends_on:
+          - db
+        ports:
+         - "8080:80"

--- a/src/Controller/ConnectController.php
+++ b/src/Controller/ConnectController.php
@@ -96,6 +96,7 @@ class ConnectController extends Controller
 
         $isLoggedIn = false;
         $userId     = 0;
+        $username   = '';
         
         if(FE_USER_LOGGED_IN === true) {
             $username = $this->container->get('security.token_storage')->getToken()->getUsername();
@@ -105,14 +106,16 @@ class ConnectController extends Controller
                 $isLoggedIn = true;
                 $userId     = $phpBBuser->user_id;
             } else {
-                System::log('Request from phpbb to autologin a user which was found in Contao but not in phpbb: '.$username, __METHOD__, TL_ERROR);
+                System::log('Request from phpbb to autologin a user which was found in Contao but not in phpbb: ' . $username, __METHOD__, TL_ERROR);
+                $isLoggedIn = true;
             }
         }
 
         $response = new JsonResponse();
         $response->setData(array(
             'is_logged_in' => $isLoggedIn,
-            'user_id'      => (int)$userId
+            'user_id'      => (int)$userId,
+            'username'     => $username,
         ));
 
         return $response;
@@ -168,7 +171,7 @@ class ConnectController extends Controller
         if($result === false) {
             $statusCode = 'FAILURE';
         }
-        
+
         // A user was locked so we also need to lock on phpbb side
         if($result === false && $user->locked > 0 && $user->locked + Config::get('lockPeriod') > time()) {
             $statusCode = 'LOCKED';

--- a/src/EventListener/ContaoMemberListener.php
+++ b/src/EventListener/ContaoMemberListener.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * This file is part of contao-phpbb-bridge-bundle
+ * 
+ * Copyright (c) CTS GmbH
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ * 
+ */
+
+namespace Ctsmedia\Phpbb\BridgeBundle\EventListener;
+
+
+use Contao\FrontendUser;
+use Contao\ModulePersonalData;
+use Contao\User;
+use Ctsmedia\Phpbb\BridgeBundle\PhpBB\Connector;
+use Monolog\Logger;
+
+
+/**
+ *
+ * @package Ctsmedia\Phpbb\BridgeBundle\EventListener
+ * @author Daniel Schwiperich <d.schwiperich@cts-media.eu>
+ */
+class ContaoMemberListener
+{
+    /**
+     * @var Connector
+     */
+    private $phpBBConnector;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+
+    /**
+     * ContaoMemberListener constructor.
+     * @param Connector $phpBBConnector
+     * @param Logger $logger
+     */
+    public function __construct(Connector $phpBBConnector, Logger $logger)
+    {
+
+        $this->phpBBConnector = $phpBBConnector;
+        $this->logger = $logger;
+    }
+
+
+    /**
+     * Updates the phpbb user if the contao member profile changes. Currently only email is supported
+     * since this is the only field in both systems
+     *
+     * username is not changeable.
+     * password @see onSetNewPassword
+     *
+     * Contao Hook: updatePersonalData
+     *
+     * @param User $user
+     * @param array $data
+     * @param ModulePersonalData $modulePersonalData
+     */
+    public function onUpdatePersonalData(User $user, array $data, ModulePersonalData $modulePersonalData)
+    {
+        // We are only interested in Contao Members
+        if (!$user instanceof FrontendUser) {
+            return;
+        }
+
+        if (isset($data['email'])) {
+            $phpBBUser = $this->phpBBConnector->getUser($user->username);
+            // If a correspondenting phpBB User was found sync  emails
+            if ($phpBBUser !== null) {
+                $success = $this->phpBBConnector->updateUser($phpBBUser->user_id, ['user_email' => $data['email']]);
+                if ($success) {
+                    $this->logger->info("Member {$user->username} email was synced to his phpbb profile");
+                }
+            }
+        }
+
+
+    }
+
+    /**
+     * Invalidate phpBB user password if contao member changed his one.
+     * phpBB will then ask contao on next login if given password matches and update the phpbb user password accordingly
+     *
+     * Contao Hook: setNewPassword
+     *
+     * @param $user
+     * @param $strPassword
+     */
+    public function onSetNewPassword($user, $strPassword)
+    {
+        $phpBBUser = $this->phpBBConnector->getUser($user->username);
+        // If a correspondenting phpBB User was found sync  emails
+        if ($phpBBUser !== null) {
+            $success = $this->phpBBConnector->updateUser($phpBBUser->user_id, ['user_password' => Connector::IMPORT_USER_PASSWORD_PREFIX . $strPassword]);
+            if ($success) {
+                $this->logger->info("Member {$user->username} updated his password. phpbb password was invalidated therefore.");
+            }
+        }
+    }
+
+}

--- a/src/PhpBB/Connector.php
+++ b/src/PhpBB/Connector.php
@@ -39,6 +39,12 @@ use Symfony\Component\Yaml\Yaml;
  */
 class Connector
 {
+
+    /**
+     * on change also update ctsmedia\contaophpbbbridge\contao\Connector
+     */
+    const IMPORT_USER_PASSWORD_PREFIX = 'contao-';
+
     /**
      * @var Connection
      */
@@ -150,6 +156,35 @@ class Connector
 
         return $result;
     }
+
+    /**
+     * Updates a phpbb user, returns true on success
+     *
+     * data should look like:
+     * [
+     *  'field_name' => 'value',
+     *  'user_email' => 'test@test.com'
+     * ]
+     *
+     *
+     * @param $userID
+     * @param array $data
+     *
+     * @return bool
+     */
+    public function updateUser($userID, array $data)
+    {
+        $queryBuilder = $this->db->createQueryBuilder()
+            ->update($this->table_prefix . 'users', 'pu');
+        foreach ($data as $field => $value){
+            $queryBuilder->set("pu.{$field}", $queryBuilder->expr()->literal($value));
+        }
+        $queryBuilder->where('pu.user_id = :user_id')
+            ->setParameter('user_id', (int)$userID);
+
+        return (1 === $queryBuilder->execute());
+    }
+
 
     /**
      * Retrieves User Profile Data by a given phpbb userId

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -3,3 +3,9 @@ services:
         class: Ctsmedia\Phpbb\BridgeBundle\PhpBB\Connector
         arguments:
             - "@database_connection"
+    phpbb_bridge.event_listener.contao_member_listener:
+        class: Ctsmedia\Phpbb\BridgeBundle\EventListener\ContaoMemberListener
+        public: true
+        arguments:
+          - "@phpbb_bridge.connector"
+          - "@monolog.logger.contao"

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -20,6 +20,10 @@ $GLOBALS['TL_HOOKS']['importUser'][] = array('\\Ctsmedia\\Phpbb\\BridgeBundle\\E
 $GLOBALS['TL_HOOKS']['checkCredentials'][] = array('\\Ctsmedia\\Phpbb\\BridgeBundle\\EventListener\\ContaoFrontendListener', 'onCheckCredentials');
 $GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('\\Ctsmedia\\Phpbb\\BridgeBundle\\EventListener\\ContaoFrontendListener', 'onReplaceInsertTags');
 $GLOBALS['TL_HOOKS']['postLogout'][] = array('\\Ctsmedia\\Phpbb\\BridgeBundle\\EventListener\\ContaoFrontendListener', 'onLogout');
+$GLOBALS['TL_HOOKS']['updatePersonalData'][] = array('phpbb_bridge.event_listener.contao_member_listener', 'onUpdatePersonalData');
+$GLOBALS['TL_HOOKS']['setNewPassword'][] = array('phpbb_bridge.event_listener.contao_member_listener', 'onSetNewPassword');
+
+
 
 
 /**

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -115,11 +115,17 @@ class tl_page_phpbbforum extends tl_page {
             'dbname' => System::getContainer()->getParameter('database_name'),
         ];
 
+        $forumGroups = $dc->activeRecord->phpbb_default_groups;
+        if(is_string($dc->activeRecord->phpbb_default_groups)) {
+            $forumGroups = unserialize($dc->activeRecord->phpbb_default_groups);
+        }
+
         System::getContainer()->get('phpbb_bridge.connector')->updateConfig(array(
             'contao.forum_pageId' => $dc->activeRecord->id,
             'contao.forum_pageUrl' => Environment::get('url').'/'.$url,
             'contao.url' => Environment::get('url'),
             'contao.forum_pageAlias' => $dc->activeRecord->phpbb_alias,
+            'contao.forum_groups' => $forumGroups,
             'contao.bridge_is_installed' => true,
             'contao.db' => $db
         ));

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/composer.json
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/composer.json
@@ -19,7 +19,7 @@
     "extra": {
         "display-name": "Contao phpBB Bridge",
         "soft-require": {
-            "phpbb/phpbb": "3.1.*"
+            "phpbb/phpbb": "^3.1.0"
         }
     },
     "minimum-stability": "dev",

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/contao.yml.dist
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/contao.yml.dist
@@ -2,6 +2,7 @@ parameters:
     contao.forum_pageId: ~
     contao.forum_pageUrl: ~
     contao.forum_pageAlias: ~
+    contao.forum_groups: []
     contao.url: ~
     contao.body_class: ~
     contao.bridge_is_installed: false

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/services.yml
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/services.yml
@@ -9,6 +9,7 @@ services:
             - '%contao.forum_pageId%'
             - '%contao.url%'
             - '%contao.db%'
+            - '%contao.forum_groups%'
             - '@user'
             - '@auth'
             - '@request'

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/services.yml
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/config/services.yml
@@ -12,6 +12,9 @@ services:
             - '@user'
             - '@auth'
             - '@request'
+            - '@dbal.conn'
+            - %core.root_path%
+            - %core.php_ext%
     ctsmedia.contaophpbbbridge.theme_listener:
         class: ctsmedia\contaophpbbbridge\event\ThemeListener
         arguments:

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/contao/AuthProvider.php
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/contao/AuthProvider.php
@@ -169,6 +169,7 @@ class AuthProvider extends db
         }
 
         $result = parent::login($username, $password);
+        $contaoLogin = null;
 
         // In admin area we completely skip contao
         if(defined('ADMIN_START')) {
@@ -178,10 +179,47 @@ class AuthProvider extends db
             return $result;
         }
 
+        // if the user is not found in the phpbb user base look at contao and import
+        if($result['status'] == LOGIN_ERROR_USERNAME){
+            $contaoUser = $this->contaoConnector->getContaoUser($username);
+
+            // found a contao user, try to import
+            if (false !== $contaoUser) {
+                try{
+                    if($this->debug) {
+                        $this->logger->debug("User {$username} not found in phpbb on login attempt. Trying to import");
+                    }
+                    $this->contaoConnector->importUser($username);
+                    $result = parent::login($username, $password);
+                } catch (\InvalidArgumentException $e) {}
+            }
+        }
+
+        // if the password check is wrong it maybe due to a imported user from contao
+        if($result['status'] == LOGIN_ERROR_PASSWORD){
+            // test if phpbb user password is prefixed with import password prefix
+            if(false !== strpos($result['user_row']['user_password'], Connector::IMPORT_USER_PASSWORD_PREFIX)) {
+                $contaoLogin = $this->contaoConnector->login($username, $password, $this->request->is_set_post('autologin'));
+
+                if ($this->debug) {
+                    $this->logger->debug('Login on imported user with import password. Trying to login via contao and set password' , ['contao_login_status' => $contaoLogin['status']]);
+                }
+
+                // Set password to imported phpbbuser
+                if($contaoLogin['status'] === true) {
+                    $sql = "UPDATE " . USERS_TABLE .
+                        " SET user_password = '{$this->db->sql_escape($this->passwords_manager->hash($password))}'" .
+                        " WHERE user_id = " . (int)$result['user_row']['user_id'];
+                    $this->db->sql_query($sql);
+                    $result = parent::login($username, $password);
+                }
+            }
+        }
+
         // We only need to trigger contao login if the phpbb login was successful
         if($result['status'] == LOGIN_SUCCESS){
-            $contaoLogin = $this->contaoConnector->login($username, $password, $this->request->is_set_post('autologin'));
-            
+            $contaoLogin = ($contaoLogin !== null) ? $contaoLogin : $this->contaoConnector->login($username, $password, $this->request->is_set_post('autologin'));
+
             // Account was locked on contao side
             if($contaoLogin['status'] === false && $contaoLogin['code'] == 'LOCKED') {
                 $result =  array(

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/contao/AuthProvider.php
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/contao/AuthProvider.php
@@ -107,6 +107,14 @@ class AuthProvider extends db
             $this->logger->debug(__METHOD__, ['logoutInProgress' => $this->logoutInProgress]);
         }
 
+        // In admin area we completely skip contao
+        if(defined('ADMIN_START')) {
+            if ($this->debug) {
+                $this->logger->debug('Admin Area detected. Skipping Contao autologin');
+            }
+            return;
+        }
+
         // phpbb initializes a new session after logout without reload
         // so the autologin cookies are still in the current request. So just stop here
         if($this->logoutInProgress === true) {
@@ -138,6 +146,7 @@ class AuthProvider extends db
         // We want to avoid that users can be auto logged in to phpbb via cookies
         // so we clean the table, because phpbb does not check if it's allowed to autologin the user
         if(empty($user_data)) {
+
             $sql = 'DELETE FROM ' . SESSIONS_KEYS_TABLE;
             $this->db->sql_query($sql);
         }
@@ -160,6 +169,15 @@ class AuthProvider extends db
         }
 
         $result = parent::login($username, $password);
+
+        // In admin area we completely skip contao
+        if(defined('ADMIN_START')) {
+            if ($this->debug) {
+                $this->logger->debug('Admin Login detected. Skipping Contao login sync', ['user' => $username]);
+            }
+            return $result;
+        }
+
         // We only need to trigger contao login if the phpbb login was successful
         if($result['status'] == LOGIN_SUCCESS){
             $contaoLogin = $this->contaoConnector->login($username, $password, $this->request->is_set_post('autologin'));

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/contao/Connector.php
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/contao/Connector.php
@@ -39,6 +39,9 @@ require_once __DIR__."/../vendor/autoload.php";
  */
 class Connector
 {
+    /**
+     * on change also update Ctsmedia\Phpbb\BridgeBundle\PhpBB\Connector
+     */
     const IMPORT_USER_PASSWORD_PREFIX = 'contao-';
 
     protected $isBridgeInstalled;


### PR DESCRIPTION
This PR add the feature that contao members (in selected member groups) get synced from contao to phpbb. 
Until now this was only possible the other way around. 

Contao Member will now become phpBB user on autologin action (which is fired by phpbb everytime a anonymois user visits the forum without session), on login to forum, and when a member is logged in to contao and heads over to the forum (autologin takes care of it even if no remember me is set)

We also sync the member email to phpbb if a member changes it (no other fields which exist in both system, except username (not changeable) and password (see next) )

If a member changes its password the phpbb password becomes invalid. So user needs to use contao member password which will get syncs the next time the member logins to the forum. 

- Import User when user is already logged in to contao
- Import User via autologin
- Import User on phpbb login
- make contao passwort reset usable
- sync contao member field updates (email, password, username) to phpbb

closes #36 
