### PR TITLE
use the ^ instead of the ~  kriswallsmith/buzz

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.6|^7.0",
         "contao/core-bundle": "^4.0.4",
-        "kriswallsmith/buzz": "~0.15"
+        "kriswallsmith/buzz": "^0.15"
     },
     "require-dev": {
         "contao/managed-edition": "^4.4",

--- a/src/Resources/phpBB/ctsmedia/contaophpbbbridge/composer.json
+++ b/src/Resources/phpBB/ctsmedia/contaophpbbbridge/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "kriswallsmith/buzz": "~0.15",
+        "kriswallsmith/buzz": "^0.15",
         "monolog/monolog": "^1.19"
     },
     "extra": {


### PR DESCRIPTION
use the ^ instead of the ~ because it's a pre release version of kriswallsmith/buzz and 0.17 introduces bc breaks

and the ^ considers this for pre 1.0 versions.
> For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0
https://getcomposer.org/doc/articles/versions.md#caret-version-range-

fixes #43 