### PR TITLE
do not extend from tl_settings

### DIFF
--- a/src/Resources/contao/dca/tl_settings.php
+++ b/src/Resources/contao/dca/tl_settings.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['lockPeriod']['save_callback'][] = a
 $GLOBALS['TL_DCA']['tl_settings']['config']['onsubmit_callback'][] = array('tl_settings_phpbbforum', 'onSubmitCallback');
 
 
-class tl_settings_phpbbforum extends tl_settings {
+class tl_settings_phpbbforum {
 
     protected $clearPhpbbCache = false;
 


### PR DESCRIPTION
The `tl_settings` class has been removed in newer Contao versions. Since you are not using any of its, or its parents methods or properties, you do not have to and should not extend from it.